### PR TITLE
Added an optional refresh parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.3.13",
     "expect": "^1.13.4",
-    "mocha": "^2.3.4"
+    "mocha": "^2.3.4",
+    "proxyquire": "^1.8.0",
+    "sinon": "^4.1.2"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,12 @@ var getIpAddresses = require('get-ip-addresses').getIpAddresses;
 console.log(getIpAddresses());
 ~~~
 
+### Refresh IP Addresses
+By default, the list of IP addresses is cached. To force a refresh, you can pass an additional parameter.
+~~~es6
+getIpAddresses(true);
+~~~
+
 ## Kudos
 Liberated from this StackOverflow answer: http://stackoverflow.com/a/8440736
 

--- a/src/get-ip-addresses.js
+++ b/src/get-ip-addresses.js
@@ -5,7 +5,11 @@ import {map, filter, flatten} from 'lodash';
 
 let ifaces = os.networkInterfaces();
 
-export default function getIpAddresses () {
+export default function getIpAddresses (refresh = false) {
+  if (refresh) {
+    ifaces = os.networkInterfaces();
+  }
+
   return flatten(map(Object.keys(ifaces), ifname => {
     let interfaces = filter(ifaces[ifname], {family: 'IPv4', internal: false});
     return map(interfaces, 'address');

--- a/src/get-ip-addresses.js
+++ b/src/get-ip-addresses.js
@@ -5,7 +5,7 @@ import {map, filter, flatten} from 'lodash';
 
 let ifaces = os.networkInterfaces();
 
-export default function getIpAddresses (refresh = false) {
+export default function getIpAddresses(refresh = false) {
   if (refresh) {
     ifaces = os.networkInterfaces();
   }

--- a/tests/get-ip-addresses-tests.js
+++ b/tests/get-ip-addresses-tests.js
@@ -5,7 +5,7 @@ import os from 'os';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
-describe('get ip addresses', function() {
+describe('get ip addresses', () => {
   let spy;
   let getIpAddresses;
 
@@ -21,7 +21,7 @@ describe('get ip addresses', function() {
     spy.restore();
   });
 
-	it('works on my machine', function() {
+	it('works on my machine', () => {
     // Arrange
 
     // Act

--- a/tests/get-ip-addresses-tests.js
+++ b/tests/get-ip-addresses-tests.js
@@ -11,17 +11,15 @@ describe('get ip addresses', () => {
 
   beforeEach(() => {
     spy = sinon.spy(os, 'networkInterfaces');
-    getIpAddresses = proxyquire('../src/get-ip-addresses', {
-      'os' : os
-    }).default;
-    spy.reset();    
+    getIpAddresses = proxyquire('../src/get-ip-addresses', {'os': os}).default;
+    spy.reset();
   });
 
   afterEach(() => {
     spy.restore();
   });
 
-	it('works on my machine', () => {
+  it('works on my machine', () => {
     // Arrange
 
     // Act
@@ -30,12 +28,12 @@ describe('get ip addresses', () => {
     // Assert
     expect(addresses.length).toNotEqual(0);
   });
-  
+
   it('should not refresh if no parameters are given', () => {
     // Arrange
 
     // Act
-    const addresses = getIpAddresses();    
+    const addresses = getIpAddresses();
 
     // Assert
     expect(spy.called).toBeFalsy();

--- a/tests/get-ip-addresses-tests.js
+++ b/tests/get-ip-addresses-tests.js
@@ -14,6 +14,7 @@ describe('get ip addresses', function() {
     getIpAddresses = proxyquire('../src/get-ip-addresses', {
       'os' : os
     }).default;
+    spy.reset();    
   });
 
   afterEach(() => {
@@ -28,5 +29,35 @@ describe('get ip addresses', function() {
 
     // Assert
     expect(addresses.length).toNotEqual(0);
-	});
+  });
+  
+  it('should not refresh if no parameters are given', () => {
+    // Arrange
+
+    // Act
+    const addresses = getIpAddresses();    
+
+    // Assert
+    expect(spy.called).toBeFalsy();
+  });
+
+  it('should not refresh if parameter is false', () => {
+    // Arrange
+
+    // Act
+    const addresses = getIpAddresses(false);
+
+    // Assert
+    expect(spy.called).toBeFalsy();
+  });
+
+  it('should not refresh if parameter is true', () => {
+    // Arrange
+
+    // Act
+    const addresses = getIpAddresses(true);
+
+    // Assert
+    expect(spy.called).toBeTruthy();
+  });
 })

--- a/tests/get-ip-addresses-tests.js
+++ b/tests/get-ip-addresses-tests.js
@@ -1,10 +1,32 @@
 'use strict';
 
 import expect from 'expect';
-import getIpAddresses from '../src/get-ip-addresses';
+import os from 'os';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
 
-describe('get ip addresses', function () {
-  it('works on my machine', function () {
-    expect(getIpAddresses().length).toNotEqual(0);
-  })
+describe('get ip addresses', function() {
+  let spy;
+  let getIpAddresses;
+
+  beforeEach(() => {
+    spy = sinon.spy(os, 'networkInterfaces');
+    getIpAddresses = proxyquire('../src/get-ip-addresses', {
+      'os' : os
+    }).default;
+  });
+
+  afterEach(() => {
+    spy.restore();
+  });
+
+	it('works on my machine', function() {
+    // Arrange
+
+    // Act
+    const addresses = getIpAddresses();
+
+    // Assert
+    expect(addresses.length).toNotEqual(0);
+	});
 })


### PR DESCRIPTION
I added an optional parameter which, if set to true, causes the function to refresh the list of IP addresses. This is a non-breaking change to the original API. I also added more unit tests and spies that verify this behavior.